### PR TITLE
fix(install): latest release with .tar.gz file & add support for mac arm64 (silicon)

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -19,10 +19,11 @@ if test -f "$release_file.zip";
 then
     #  Extract contents of zip file into the download directory
     unzip -p "$release_file.zip" | tar -xvf - -C "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
+    # Remove the zip file since we don't need to keep it
+    rm "$release_file.zip"
 else
     # Extract contents of .tar.gz file into the download directory
     tar -xvzf "$release_file.tar.gz" -C "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
+    # Remove the zip file since we don't need to keep it
+    rm "$release_file.tar.gz"
 fi
-
-# Remove the zip file since we don't need to keep it
-rm "$release_file"

--- a/bin/download
+++ b/bin/download
@@ -10,7 +10,7 @@ source "${plugin_dir}/lib/utils.bash"
 
 mkdir -p "$ASDF_DOWNLOAD_PATH"
 
-release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.zip"
+release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.tar.gz"
 
 # Download zip file to the download directory
 download_release "$ASDF_INSTALL_VERSION" "$release_file"

--- a/bin/download
+++ b/bin/download
@@ -10,13 +10,19 @@ source "${plugin_dir}/lib/utils.bash"
 
 mkdir -p "$ASDF_DOWNLOAD_PATH"
 
-release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.tar.gz"
+release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION"
 
 # Download zip file to the download directory
 download_release "$ASDF_INSTALL_VERSION" "$release_file"
 
-#  Extract contents of zip file into the download directory
-unzip -p "$release_file" | tar -xvf - -C "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
+if test -f "$release_file.zip";
+then
+    #  Extract contents of zip file into the download directory
+    unzip -p "$release_file.zip" | tar -xvf - -C "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
+else
+    # Extract contents of .tar.gz file into the download directory
+    tar -xvzf "$release_file.tar.gz" -C "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
+fi
 
 # Remove the zip file since we don't need to keep it
 rm "$release_file"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -43,7 +43,7 @@ download_release() {
 	url="$GH_REPO/releases/download/${version}/${TOOL_NAME}-${os}-${processor}"
 
 	echo "* Downloading $TOOL_NAME release $version..."
-	curl "${curl_opts[@]}" -o "$filename" -C - "$url.tar.gz" || curl "${curl_opts[@]}" -o "$filename" -C - "$url.zip" || fail "Could not download $url"
+	curl "${curl_opts[@]}" -o "$filename.tar.gz" -C - "$url.tar.gz" || curl "${curl_opts[@]}" -o "$filename.zip" -C - "$url.zip" || fail "Could not download $url"
 }
 
 install_version() {

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -40,10 +40,10 @@ download_release() {
 	processor=$(get_machine_processor)
 	os=$(get_machine_os)
 
-	url="$GH_REPO/releases/download/${version}/${TOOL_NAME}-${os}-${processor}.zip"
+	url="$GH_REPO/releases/download/${version}/${TOOL_NAME}-${os}-${processor}"
 
 	echo "* Downloading $TOOL_NAME release $version..."
-	curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"
+	curl "${curl_opts[@]}" -o "$filename" -C - "$url.tar.gz" || curl "${curl_opts[@]}" -o "$filename" -C - "$url.zip" || fail "Could not download $url"
 }
 
 install_version() {

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -85,6 +85,7 @@ get_machine_os() {
 get_machine_processor() {
 	KERNEL=$(uname -m)
 	case "${KERNEL}" in
+	arm64*) echo 'arm64' ;;
 	x86_64*) echo 'x64' ;;
 	*)
 		# dump error to stderr


### PR DESCRIPTION
Plugin install is currenlty failing because the hledger releases files have changed the file type (to `.tar.gz` extension from the `.zip` extension)

This PR will add support for downloading `.tar.gz` files while keeping support for `.zip` files to keep the compatibility with older versions of hledger

This PR also adds supports for the arm64 architecture on the new Mac Silicon chip (fixes #8)

## Quick Start
```sh
mise plugin add https://github.com/saul-salazar-dotcom/asdf-hledger

# download latest version:
mise use -g hledger

# download older version:
mise use -g hledger@1.30
```
